### PR TITLE
Log original URL in GoatCounter for 404 pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,3 +23,10 @@ layout: page
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
 </div>
+
+{%- if site.goatcounter -%}
+<script>
+  window.goatcounter = window.goatcounter || {};
+  window.goatcounter.path = '/404 - ' + location.pathname + location.search;
+</script>
+{%- endif -%}


### PR DESCRIPTION
Override the GoatCounter path on the 404 page to include the originally requested URL, making it possible to see which pages visitors are trying to reach.

-----

`404.html` is currently the most visited page so I'd like to see which pages are actually being visited so we can set some redirects.