### PR TITLE
Add symlinks for old udisks2-api version URLs to redirect to current …

### DIFF
--- a/doc/udisks2-api/2.10.0
+++ b/doc/udisks2-api/2.10.0
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.10.1
+++ b/doc/udisks2-api/2.10.1
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.10.90
+++ b/doc/udisks2-api/2.10.90
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.11.0
+++ b/doc/udisks2-api/2.11.0
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.6.5
+++ b/doc/udisks2-api/2.6.5
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.0
+++ b/doc/udisks2-api/2.7.0
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.1
+++ b/doc/udisks2-api/2.7.1
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.2
+++ b/doc/udisks2-api/2.7.2
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.3
+++ b/doc/udisks2-api/2.7.3
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.4
+++ b/doc/udisks2-api/2.7.4
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.5
+++ b/doc/udisks2-api/2.7.5
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.6
+++ b/doc/udisks2-api/2.7.6
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.7.7
+++ b/doc/udisks2-api/2.7.7
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.8.0
+++ b/doc/udisks2-api/2.8.0
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.8.1
+++ b/doc/udisks2-api/2.8.1
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.8.2
+++ b/doc/udisks2-api/2.8.2
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.8.3
+++ b/doc/udisks2-api/2.8.3
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.8.4
+++ b/doc/udisks2-api/2.8.4
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.9.0
+++ b/doc/udisks2-api/2.9.0
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.9.1
+++ b/doc/udisks2-api/2.9.1
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.9.2
+++ b/doc/udisks2-api/2.9.2
@@ -1,0 +1,1 @@
+../../udisks/docs

--- a/doc/udisks2-api/2.9.4
+++ b/doc/udisks2-api/2.9.4
@@ -1,0 +1,1 @@
+../../udisks/docs


### PR DESCRIPTION
…docs

Old versioned URLs like /doc/udisks2-api/2.7.7/ stopped working after the documentation was moved to /udisks/docs/. Add symlinks for all old versions pointing to the current documentation location.

----

Based on the "data" from #16 it looks like most of the 404s we get are results of old udisks documentation links. This is a simple quick fix, I don't expect people are actually intentionally looking for old documentation so redirecting to the latest should be fine.